### PR TITLE
Add dependencies to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-
+numpy
+matplotlib
+ace_tools


### PR DESCRIPTION
## Summary
- list numpy, matplotlib, and ace_tools in requirements.txt

## Testing
- `python3 -m py_compile src/*.py`
